### PR TITLE
[bdg-utils-17] Upgrade to Spark 1.2 and cross-compile to scala 2.10 and 2.11

### DIFF
--- a/bdg-utils-metrics/pom.xml
+++ b/bdg-utils-metrics/pom.xml
@@ -7,7 +7,7 @@
     <version>0.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>bdg-utils-metrics</artifactId>
+  <artifactId>bdg-utils-metrics_${scala.artifact.suffix}</artifactId>
   <packaging>jar</packaging>
   <name>bdg-utils-metrics: tools for collecting metrics on top of RDDs</name>
   <build>

--- a/bdg-utils-minhash/pom.xml
+++ b/bdg-utils-minhash/pom.xml
@@ -7,7 +7,7 @@
     <version>0.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>bdg-utils-minhash</artifactId>
+  <artifactId>bdg-utils-minhash_${scala.artifact.suffix}</artifactId>
   <packaging>jar</packaging>
   <name>bdg-utils-minhash: MinHash-based Jaccard similarity estimator</name>
   <build>

--- a/bdg-utils-misc/pom.xml
+++ b/bdg-utils-misc/pom.xml
@@ -7,7 +7,7 @@
     <version>0.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>bdg-utils-misc</artifactId>
+  <artifactId>bdg-utils-misc_${scala.artifact.suffix}</artifactId>
   <packaging>jar</packaging>
   <name>bdg-utils-misc: Miscellaneous Spark helper code</name>
   <build>

--- a/bdg-utils-parquet/pom.xml
+++ b/bdg-utils-parquet/pom.xml
@@ -7,7 +7,7 @@
     <version>0.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>bdg-utils-parquet</artifactId>
+  <artifactId>bdg-utils-parquet_${scala.artifact.suffix}</artifactId>
   <packaging>jar</packaging>
   <name>bdg-utils-parquet: Parquet Extensions</name>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <java.version>1.7</java.version>
     <scala.version>2.10.4</scala.version>
     <scala.artifact.suffix>2.10</scala.artifact.suffix>
-    <spark.version>1.1.0</spark.version>
+    <spark.version>1.2.0</spark.version>
     <parquet.version>1.4.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
@@ -90,7 +90,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.1.5</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -313,7 +313,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <scope>provided</scope>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
@@ -340,6 +345,7 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
@@ -374,6 +380,13 @@
   </dependencyManagement>
 
   <profiles>
+    <profile>
+      <id>scala-2.11</id>
+      <properties>
+        <scala.version>2.11.2</scala.version>
+        <scala.artifact.suffix>2.11</scala.artifact.suffix>
+      </properties>
+    </profile>
     <!-- Only build coverage in when we want to run coverage -->
     <profile>
       <id>coverage</id>

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 mvn -Dresume=false release:clean release:prepare release:perform
+
+mvn -Dresume=false -P scala-2.11 release:clean release:prepare release:perform

--- a/scripts/release/rollback.sh
+++ b/scripts/release/rollback.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 mvn release:rollback
+
+mvn -P scala-2.11 release:rollback


### PR DESCRIPTION
Resolves #17. Upgrades bdg-utils to Spark 1.2, and moves Spark and Hadoop to provided dependencies. Shades `com.google.guava` out of Hadoop to prevent unit test failures due to conflicting `guava` versions in Spark and Hadoop. Adds a profile to the parent pom.xml to allow for us to cross-compile to scala 2.10 and 2.11, and adds the Scala binary version to the artifact names.

Paging @massie @heuermh for review, I'd like to port these changes downstream to ADAM, so I'd like thoughts about how this approach looks.