### PR TITLE
[bdg-utils-25] Upgrade to Spark 1.2.0.

### DIFF
--- a/bdg-utils-metrics/src/main/scala/org/apache/spark/rdd/InstrumentedRDD.scala
+++ b/bdg-utils-metrics/src/main/scala/org/apache/spark/rdd/InstrumentedRDD.scala
@@ -415,7 +415,7 @@ object InstrumentedRDD {
   private def rddOperationTimer(): Timer = {
     // We can only do this because we are in an org.apache.spark package (Utils is private to Spark). When we fix that
     // we'll have to implement our own getCallSite function
-    val callSite = Utils.getCallSite.shortForm
+    val callSite = Utils.getCallSite().shortForm
     new Timer(callSite, clock = clock, recorder = None,
       sequenceId = Some(Metrics.generateNewSequenceId()), isRDDOperation = true)
   }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <java.version>1.7</java.version>
     <scala.version>2.10.4</scala.version>
     <scala.artifact.suffix>2.10</scala.artifact.suffix>
-    <spark.version>1.1.0</spark.version>
+    <spark.version>1.2.0</spark.version>
     <parquet.version>1.6.0rc4</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
@@ -313,7 +313,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <scope>provided</scope>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
@@ -340,6 +345,7 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Resolves #25. However, the trouble with this patch is that the metrics code is now locked to Spark 1.2.0. Essentially, since the "getCallSite" API is internal to Spark, they made a change between 1.1.0 and 1.2.0 that is binary incompatible (specifically, they added _an optional argument_ and Java cannot deal). You _can_ still run with Spark 1.1.0 with this, but you can't use the metrics code.

Would love any thoughts from @massie @nfergu . I feel like there _should_ be a way around this, but alas am not seeing one.