### PR TITLE
Instrumented some new RDD operations from Spark 1.2

### DIFF
--- a/bdg-utils-metrics/src/main/scala/org/apache/spark/rdd/InstrumentedOrderedRDDFunctions.scala
+++ b/bdg-utils-metrics/src/main/scala/org/apache/spark/rdd/InstrumentedOrderedRDDFunctions.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.spark.rdd
 
+import org.apache.spark.Partitioner
 import org.apache.spark.SparkContext.rddToOrderedRDDFunctions
 import org.apache.spark.rdd.InstrumentedRDD._
 import scala.reflect.ClassTag
@@ -32,6 +33,13 @@ class InstrumentedOrderedRDDFunctions[K: Ordering: ClassTag, V: ClassTag](self: 
       instrument(self.sortByKey(ascending, numPartitions))
     }
     case _ => self.sortByKey(ascending, numPartitions)
+  }
+
+  def repartitionAndSortWithinPartitions(partitioner: Partitioner): RDD[(K, V)] = self match {
+    case instrumented: InstrumentedRDD[_] => recordOperation {
+      instrument(self.repartitionAndSortWithinPartitions(partitioner))
+    }
+    case _ => self.repartitionAndSortWithinPartitions(partitioner)
   }
 
 }

--- a/bdg-utils-metrics/src/main/scala/org/apache/spark/rdd/InstrumentedPairRDDFunctions.scala
+++ b/bdg-utils-metrics/src/main/scala/org/apache/spark/rdd/InstrumentedPairRDDFunctions.scala
@@ -246,6 +246,13 @@ class InstrumentedPairRDDFunctions[K, V](self: RDD[(K, V)])(implicit kt: ClassTa
     case _ => self.rightOuterJoin(other, partitioner)
   }
 
+  def fullOuterJoin[W](other: RDD[(K, W)], partitioner: Partitioner): RDD[(K, (Option[V], Option[W]))] = self match {
+    case instrumented: InstrumentedRDD[_] => recordOperation {
+      instrument(self.fullOuterJoin(other, partitioner))
+    }
+    case _ => self.fullOuterJoin(other, partitioner)
+  }
+
   def combineByKey[C](createCombiner: (V) => C, mergeValue: (C, V) => C, mergeCombiners: (C, C) => C): RDD[(K, C)] = self match {
     case instrumented: InstrumentedRDD[_] => recordOperation {
       implicit val recorder = functionRecorder()
@@ -301,6 +308,20 @@ class InstrumentedPairRDDFunctions[K, V](self: RDD[(K, V)])(implicit kt: ClassTa
       instrument(self.rightOuterJoin(other, numPartitions))
     }
     case _ => self.rightOuterJoin(other, numPartitions)
+  }
+
+  def fullOuterJoin[W](other: RDD[(K, W)]): RDD[(K, (Option[V], Option[W]))] = self match {
+    case instrumented: InstrumentedRDD[_] => recordOperation {
+      instrument(self.fullOuterJoin(other))
+    }
+    case _ => self.fullOuterJoin(other)
+  }
+
+  def fullOuterJoin[W](other: RDD[(K, W)], numPartitions: Int): RDD[(K, (Option[V], Option[W]))] = self match {
+    case instrumented: InstrumentedRDD[_] => recordOperation {
+      instrument(self.fullOuterJoin(other, numPartitions))
+    }
+    case _ => self.fullOuterJoin(other, numPartitions)
   }
 
   def collectAsMap(): Map[K, V] = self match {


### PR DESCRIPTION
Added instrumentation for some new RDD operations from Spark 1.2: fullOuterJoin and repartitionAndSortWithinPartitions