### PR TITLE
Move CLI code from ADAM

### DIFF
--- a/bdg-utils-cli/pom.xml
+++ b/bdg-utils-cli/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.bdgenomics.bdg-utils</groupId>
+    <artifactId>bdg-utils-parent</artifactId>
+    <version>0.1.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>bdg-utils-cli</artifactId>
+  <packaging>jar</packaging>
+  <name>bdg-utils-cli: utilities for building command line applications</name>
+  <build>
+    <plugins>
+      <!-- disable surefire -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <!-- enable scalatest -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/main/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/test/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.bdg-utils</groupId>
+      <artifactId>bdg-utils-misc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.bdg-utils</groupId>
+      <artifactId>bdg-utils-parquet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.bdg-utils</groupId>
+      <artifactId>bdg-utils-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/bdg-utils-cli/src/main/scala/org/bdgenomics/utils/cli/Args4j.scala
+++ b/bdg-utils-cli/src/main/scala/org/bdgenomics/utils/cli/Args4j.scala
@@ -1,0 +1,64 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.cli
+
+import org.kohsuke.args4j.{ Option, CmdLineException, CmdLineParser }
+import scala.collection.JavaConversions._
+
+class Args4jBase {
+  @Option(name = "-h", aliases = Array("-help", "--help", "-?"), usage = "Print help")
+  var doPrintUsage: Boolean = false
+  @Option(name = "-print_metrics", usage = "Print metrics to the log on completion")
+  var printMetrics: Boolean = false
+}
+
+object Args4j {
+  val helpOptions = Array("-h", "-help", "--help", "-?")
+
+  def apply[T <% Args4jBase: Manifest](args: Array[String], ignoreCmdLineExceptions: Boolean = false): T = {
+    val args4j: T = manifest[T].runtimeClass.asInstanceOf[Class[T]].newInstance()
+    val parser = new CmdLineParser(args4j)
+    parser.setUsageWidth(150);
+
+    def displayHelp(exitCode: Int = 0) = {
+      parser.printUsage(System.out)
+      System.exit(exitCode)
+    }
+
+    // Work around for help processing in Args4j
+    if (args.exists(helpOptions.contains(_))) {
+      displayHelp()
+    }
+
+    try {
+      parser.parseArgument(args.toList)
+      if (args4j.doPrintUsage)
+        displayHelp()
+    } catch {
+      case e: CmdLineException =>
+        if (!ignoreCmdLineExceptions) {
+          println(e.getMessage)
+          displayHelp(1)
+        }
+    }
+
+    args4j
+  }
+
+}
+

--- a/bdg-utils-cli/src/main/scala/org/bdgenomics/utils/cli/BDGCommand.scala
+++ b/bdg-utils-cli/src/main/scala/org/bdgenomics/utils/cli/BDGCommand.scala
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.cli
+
+import java.io.{ StringWriter, PrintWriter }
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.{ SparkConf, Logging, SparkContext }
+import org.bdgenomics.utils.instrumentation._
+import org.bdgenomics.utils.misc.HadoopUtil
+
+trait BDGCommandCompanion {
+  val commandName: String
+  val commandDescription: String
+
+  def apply(cmdLine: Array[String]): BDGCommand
+
+  // Make running an BDG command easier from an IDE
+  def main(cmdLine: Array[String]) {
+    apply(cmdLine).run()
+  }
+}
+
+trait BDGCommand extends Runnable {
+  val companion: BDGCommandCompanion
+}
+
+trait BDGSparkCommand[A <: Args4jBase] extends BDGCommand with Logging {
+  protected val args: A
+
+  def run(sc: SparkContext, job: Job)
+
+  def run() {
+    val start = System.nanoTime()
+    val conf = new SparkConf().setAppName("adam: " + companion.commandName)
+    if (conf.getOption("spark.master").isEmpty) {
+      conf.setMaster("local[%d]".format(Runtime.getRuntime.availableProcessors()))
+    }
+    val sc = new SparkContext(conf)
+    val job = HadoopUtil.newJob()
+    val metricsListener = initializeMetrics(sc)
+    run(sc, job)
+    val totalTime = System.nanoTime() - start
+    printMetrics(totalTime, metricsListener)
+  }
+
+  def initializeMetrics(sc: SparkContext): Option[MetricsListener] = {
+    if (args.printMetrics) {
+      val metricsListener = new MetricsListener(new RecordedMetrics())
+      sc.addSparkListener(metricsListener)
+      Metrics.initialize(sc)
+      Some(metricsListener)
+    } else {
+      // This avoids recording metrics if we have a recorder left over from previous use of this thread
+      Metrics.stopRecording()
+      None
+    }
+  }
+
+  def printMetrics(totalTime: Long, metricsListener: Option[MetricsListener]) {
+    logInfo("Overall Duration: " + DurationFormatting.formatNanosecondDuration(totalTime))
+    if (args.printMetrics && metricsListener.isDefined) {
+      // Set the output buffer size to 4KB by default
+      val stringWriter = new StringWriter()
+      val out = new PrintWriter(stringWriter)
+      out.println("Metrics:")
+      out.println()
+      Metrics.print(out, Some(metricsListener.get.metrics.sparkMetrics.stageTimes))
+      out.println()
+      metricsListener.get.metrics.sparkMetrics.print(out)
+      out.flush()
+      logInfo(stringWriter.getBuffer.toString)
+    }
+  }
+}

--- a/bdg-utils-cli/src/main/scala/org/bdgenomics/utils/cli/ParquetArgs.scala
+++ b/bdg-utils-cli/src/main/scala/org/bdgenomics/utils/cli/ParquetArgs.scala
@@ -1,0 +1,49 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.cli
+
+import org.bdgenomics.utils.parquet.rdd.{ SaveArgs, ParquetRDDArgs }
+import org.kohsuke.args4j.{ Argument, Option }
+import parquet.hadoop.metadata.CompressionCodecName
+
+trait ParquetArgs extends Args4jBase with ParquetRDDArgs {
+  @Option(required = false, name = "-parquet_block_size", usage = "Parquet block size (default = 128mb)")
+  var blockSize = 128 * 1024 * 1024
+  @Option(required = false, name = "-parquet_page_size", usage = "Parquet page size (default = 1mb)")
+  var pageSize = 1 * 1024 * 1024
+  @Option(required = false, name = "-parquet_compression_codec", usage = "Parquet compression codec")
+  var compressionCodec = CompressionCodecName.GZIP
+  @Option(name = "-parquet_disable_dictionary", usage = "Disable dictionary encoding")
+  override var disableDictionaryEncoding = false
+  @Option(required = false, name = "-parquet_logging_level", usage = "Parquet logging level (default = severe)")
+  var logLevel = "SEVERE"
+}
+
+trait ParquetSaveArgs extends ParquetArgs with SaveArgs
+
+trait LoadFileArgs {
+  @Argument(required = true, metaVar = "INPUT", usage = "The file to load as input", index = 0)
+  var inputPath: String = null
+}
+
+trait SaveFileArgs {
+  @Argument(required = true, metaVar = "OUTPUT", usage = "The file to save as output", index = 1)
+  var outputPath: String = null
+}
+
+trait ParquetLoadSaveArgs extends ParquetSaveArgs with LoadFileArgs with SaveFileArgs

--- a/bdg-utils-misc/src/main/scala/org/bdgenomics/utils/misc/HadoopUtil.scala
+++ b/bdg-utils-misc/src/main/scala/org/bdgenomics/utils/misc/HadoopUtil.scala
@@ -1,0 +1,67 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.misc
+
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.SparkContext
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.conf.Configuration
+
+object HadoopUtil {
+
+  def newJob(): Job = {
+    newJob(new Configuration())
+  }
+
+  def newJob(config: Configuration): Job = {
+    val jobClass: Class[_] = Class.forName("org.apache.hadoop.mapreduce.Job")
+    try {
+      // Use the getInstance method in Hadoop 2
+      jobClass.getMethod("getInstance", classOf[Configuration]).invoke(null, config).asInstanceOf[Job]
+    } catch {
+      case ex: NoSuchMethodException =>
+        // Drop back to Hadoop 1 constructor
+        jobClass.getConstructor(classOf[Configuration]).newInstance(config).asInstanceOf[Job]
+    }
+  }
+
+  /**
+   * Create a job using either the Hadoop 1 or 2 API
+   * @param sc A Spark context
+   */
+  def newJob(sc: SparkContext): Job = {
+    newJob(sc.hadoopConfiguration)
+  }
+
+  /**
+   * In Hadoop 2.x, isDir is deprecated in favor of isDirectory
+   * @param fs
+   * @return
+   */
+  def isDirectory(fs: FileStatus): Boolean = {
+    val fsClass: Class[_] = fs.getClass
+    try {
+      // Use the isDirectory method in Hadoop 2
+      fsClass.getMethod("isDirectory").invoke(fs).asInstanceOf[Boolean]
+    } catch {
+      case ex: NoSuchMethodException =>
+        // Drop back to Hadoop 1 isDir method
+        fsClass.getMethod("isDir").invoke(fs).asInstanceOf[Boolean]
+    }
+  }
+}

--- a/bdg-utils-parquet/pom.xml
+++ b/bdg-utils-parquet/pom.xml
@@ -114,12 +114,16 @@
     <dependency>
       <groupId>org.bdgenomics.bdg-utils</groupId>
       <artifactId>bdg-utils-misc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.bdg-utils</groupId>
+      <artifactId>bdg-utils-misc</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.bdg-utils</groupId>
-      <artifactId>bdg-utils-misc</artifactId>
+      <artifactId>bdg-utils-metrics</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
@@ -149,12 +153,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bdgenomics.bdg-utils</groupId>
-      <artifactId>bdg-utils-misc</artifactId>
-      <version>0.1.3-SNAPSHOT</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/Timers.scala
+++ b/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/Timers.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.parquet
+
+import org.bdgenomics.utils.instrumentation.Metrics
+
+/**
+ * Contains [[Timers]] that are used to instrument ADAM.
+ */
+object Timers extends Metrics {
+  // File Saving
+  val SaveAsParquet = timer("Save File To Parquet")
+  val WriteRecord = timer("Write a Record")
+}

--- a/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/rdd/BDGParquetContext.scala
+++ b/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/rdd/BDGParquetContext.scala
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.parquet.rdd
+
+import org.apache.avro.Schema
+import org.apache.avro.specific.SpecificRecord
+import org.apache.hadoop.fs.{ FileSystem, Path }
+import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.MetricsContext._
+import org.apache.spark.{ Logging, SparkConf, SparkContext }
+import org.bdgenomics.utils.misc.HadoopUtil
+import org.bdgenomics.utils.instrumentation.Metrics
+import parquet.avro.{ AvroParquetInputFormat, AvroReadSupport }
+import parquet.filter.UnboundRecordFilter
+import parquet.hadoop.ParquetInputFormat
+import parquet.hadoop.util.ContextUtil
+import scala.reflect.ClassTag
+
+object BDGParquetContext {
+  implicit def scToBDGPContext(sc: SparkContext): BDGParquetContext = new BDGParquetContext(sc)
+
+  // Add generic RDD methods for parquet RDDs
+  implicit def rddToParquetRDD[T](rdd: RDD[T])(implicit ev1: T => SpecificRecord, ev2: Manifest[T]): BDGParquetRDDFunctions[T] = new BDGParquetRDDFunctions(rdd)
+}
+
+class BDGParquetContext(val sc: SparkContext) extends Serializable with Logging {
+
+  /**
+   * This method will create a new RDD from a parquet file.
+   * @param filePath The path to the input data
+   * @param predicate An optional pushdown predicate to use when reading the data
+   * @param projection An option projection schema to use when reading the data
+   * @tparam T The type of records to return
+   * @return An RDD with records of the specified type
+   */
+  private[rdd] def parquetLoad[T, U <: UnboundRecordFilter](filePath: String, predicate: Option[Class[U]] = None, projection: Option[Schema] = None)(implicit ev1: T => SpecificRecord, ev2: Manifest[T]): RDD[T] = {
+    //make sure a type was specified
+    //not using require as to make the message clearer
+    if (manifest[T] == manifest[scala.Nothing])
+      throw new IllegalArgumentException("Type inference failed; when loading please specify a specific type. " +
+        "e.g.:\nval reads: RDD[AlignmentRecord] = ...\nbut not\nval reads = ...\nwithout a return type")
+
+    log.info("Reading the Parquet file at %s to create RDD".format(filePath))
+    val job = HadoopUtil.newJob(sc)
+    ParquetInputFormat.setReadSupportClass(job, classOf[AvroReadSupport[T]])
+
+    if (predicate.isDefined) {
+      log.info("Using the specified push-down predicate")
+      ParquetInputFormat.setUnboundRecordFilter(job, predicate.get)
+    }
+
+    if (projection.isDefined) {
+      log.info("Using the specified projection schema")
+      AvroParquetInputFormat.setRequestedProjection(job, projection.get)
+    }
+
+    val records = sc.newAPIHadoopFile(
+      filePath,
+      classOf[ParquetInputFormat[T]],
+      classOf[Void],
+      manifest[T].runtimeClass.asInstanceOf[Class[T]],
+      ContextUtil.getConfiguration(job))
+
+    val instrumented = if (Metrics.isRecording) records.instrument() else records
+    val mapped = instrumented.map(p => p._2)
+
+    if (predicate.isDefined) {
+      // Strip the nulls that the predicate returns
+      mapped.filter(p => p != null.asInstanceOf[T])
+    } else {
+      mapped
+    }
+  }
+}

--- a/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/rdd/BDGParquetRDDFunctions.scala
+++ b/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/rdd/BDGParquetRDDFunctions.scala
@@ -1,0 +1,81 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.parquet.rdd
+
+import java.util.logging.Level
+import org.apache.avro.specific.SpecificRecord
+import org.apache.spark.Logging
+import org.apache.spark.rdd.{ InstrumentedOutputFormat, RDD }
+import org.apache.spark.rdd.MetricsContext._
+import org.bdgenomics.utils.misc.HadoopUtil
+import org.bdgenomics.utils.parquet.Timers._
+import org.bdgenomics.utils.parquet.util.ParquetLogger
+import parquet.avro.AvroParquetOutputFormat
+import parquet.hadoop.ParquetOutputFormat
+import parquet.hadoop.metadata.CompressionCodecName
+import parquet.hadoop.util.ContextUtil
+import org.apache.avro.generic.IndexedRecord
+import org.apache.hadoop.mapreduce.{ OutputFormat => NewOutputFormat, _ }
+
+trait ParquetRDDArgs {
+  var blockSize: Int
+  var pageSize: Int
+  var compressionCodec: CompressionCodecName
+  var disableDictionaryEncoding: Boolean
+}
+
+trait SaveArgs extends ParquetRDDArgs {
+  var outputPath: String
+}
+
+class BDGParquetRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Serializable with Logging {
+
+  def saveAsParquet(args: SaveArgs): Unit = {
+    saveAsParquet(
+      args.outputPath,
+      args.blockSize,
+      args.pageSize,
+      args.compressionCodec,
+      args.disableDictionaryEncoding)
+  }
+
+  def saveAsParquet(filePath: String,
+                    blockSize: Int = 128 * 1024 * 1024,
+                    pageSize: Int = 1 * 1024 * 1024,
+                    compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
+                    disableDictionaryEncoding: Boolean = false): Unit = SaveAsParquet.time {
+    val job = HadoopUtil.newJob(rdd.context)
+    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
+    ParquetOutputFormat.setCompression(job, compressCodec)
+    ParquetOutputFormat.setEnableDictionary(job, !disableDictionaryEncoding)
+    ParquetOutputFormat.setBlockSize(job, blockSize)
+    ParquetOutputFormat.setPageSize(job, pageSize)
+    AvroParquetOutputFormat.setSchema(job, manifest[T].runtimeClass.asInstanceOf[Class[T]].newInstance().getSchema)
+    // Add the Void Key
+    val recordToSave = rdd.map(p => (null, p))
+    // Save the values to the Parquet file
+    recordToSave.saveAsNewAPIHadoopFile(filePath,
+      classOf[java.lang.Void], manifest[T].runtimeClass.asInstanceOf[Class[T]], classOf[InstrumentedAvroParquetOutputFormat],
+      ContextUtil.getConfiguration(job))
+  }
+}
+
+class InstrumentedAvroParquetOutputFormat extends InstrumentedOutputFormat[Void, IndexedRecord] {
+  override def outputFormatClass(): Class[_ <: NewOutputFormat[Void, IndexedRecord]] = classOf[AvroParquetOutputFormat]
+  override def timerName(): String = WriteRecord.timerName
+}

--- a/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/util/ParquetLogger.scala
+++ b/bdg-utils-parquet/src/main/scala/org/bdgenomics/utils/parquet/util/ParquetLogger.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.utils.parquet.util
+
+import java.util.logging.{ Level, Logger }
+
+object ParquetLogger {
+
+  val hadoopLoggerLevel = (level: Level) => {
+    val parquetHadoopLogger = Logger.getLogger("parquet.hadoop")
+    parquetHadoopLogger.setLevel(level)
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>bdg-utils-metrics</module>
     <module>bdg-utils-parquet</module>
     <module>bdg-utils-statistics</module>
+    <module>bdg-utils-cli</module>
   </modules>
   
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -281,12 +281,22 @@
         <groupId>org.bdgenomics.bdg-utils</groupId>
         <artifactId>bdg-utils-misc</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bdgenomics.bdg-utils</groupId>
+        <artifactId>bdg-utils-misc</artifactId>
+        <version>${project.version}</version>
         <scope>test</scope>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.bdg-utils</groupId>
-        <artifactId>bdg-utils-misc</artifactId>
+        <artifactId>bdg-utils-parquet</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bdgenomics.bdg-utils</groupId>
+        <artifactId>bdg-utils-metrics</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -397,6 +407,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-math3</artifactId>
         <version>3.3</version>
+      </dependency>
+      <dependency>
+        <groupId>args4j</groupId>
+        <artifactId>args4j</artifactId>
+        <version>2.0.23</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Resolves #29. Moves generic CLI code (e.g., `ADAMCommand`, `Args4jBase`) over from ADAM. Also, I've pulled some of the ADAM code for loading Parquet files out. CC @tdanford @massie 